### PR TITLE
Add foreign_titles support for GeoJSON merge

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -149,12 +149,22 @@ function App() {
         }
 
         if (feature.properties) {
+          const titleValue = feature.properties.title;
+          const categoryValue = feature.properties.category_c;
+
+          feature.properties.foreign_titles = [
+            { language_code: 'ko', title: titleValue },
+            { language_code: 'en', title: categoryValue }
+          ];
+
+          feature.properties.category_c = null;
+
           const newProperties = {};
           Object.entries(feature.properties).forEach(([key, value]) => {
-            const newKey = Object.entries(keyMappings).find(([oldKey, _]) => 
+            const newKey = Object.entries(keyMappings).find(([oldKey, _]) =>
               key.startsWith(oldKey)
             );
-            
+
             newProperties[newKey ? newKey[1] : key] = value;
           });
           feature.properties = newProperties;


### PR DESCRIPTION
## Summary
- enrich `handleMerge` to add `foreign_titles` based on `title` and `category_c`
- set original `category_c` values to `null` while keeping other behaviour
- remove redundant checks around `category_c`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d9c43be68832e91d9bbdc9b9ddc28